### PR TITLE
US124288 - Add Option to Throttle Logs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @dlockhart
+*       @dlockhart @svanherk

--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ const batchSize = 500;
 const batchTime = 5000;
 
 const serverLogger = new ServerLogger(batchSize, batchTime);
-export function createClient(appId) {
-	return new LoggingClient(appId, serverLogger);
+export function createClient(appId, shouldThrottle) {
+	return new LoggingClient(appId, shouldThrottle, serverLogger);
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ const batchSize = 500;
 const batchTime = 5000;
 
 const serverLogger = new ServerLogger(batchSize, batchTime);
-export function createClient(appId, shouldThrottle) {
-	return new LoggingClient(appId, shouldThrottle, serverLogger);
+export function createClient(appId, opts) {
+	return new LoggingClient(appId, opts, serverLogger);
 }

--- a/index.js
+++ b/index.js
@@ -8,5 +8,5 @@ const batchTime = 5000;
 
 const serverLogger = new ServerLogger(batchSize, batchTime);
 export function createClient(appId, opts) {
-	return new LoggingClient(appId, opts, serverLogger);
+	return new LoggingClient(appId, serverLogger, opts);
 }

--- a/logging.js
+++ b/logging.js
@@ -158,10 +158,10 @@ export class LogBuilder {
 }
 
 export class LoggingClient {
-	constructor(appId, opts, logger) {
+	constructor(appId, logger, opts) {
 		this._appId = appId;
-		this._shouldThrottle = !!opts.shouldThrottle;
 		this._logger = logger;
+		this._shouldThrottle = opts ? !!opts.shouldThrottle : false;
 
 		this._uniqueLogs = new Map();
 	}

--- a/package.json
+++ b/package.json
@@ -31,25 +31,7 @@
     "eslint-plugin-sort-class-members": "^1",
     "eslint": "^6",
     "karma-sauce-launcher": "^2",
-    "semantic-release": "^17.1.1",
     "sinon": "^9.0.3"
   },
-  "dependencies": {},
-  "release": {
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/github",
-      "@semantic-release/npm",
-      "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json"
-          ],
-          "message": "chore(release): ${nextRelease.version} [skip ci]"
-        }
-      ]
-    ]
-  }
+  "dependencies": {}
 }

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -123,7 +123,7 @@ describe('logging', () => {
 						done();
 					}
 				};
-				const client = new LoggingClient('my-app-id', mockLogger);
+				const client = new LoggingClient('my-app-id', false, mockLogger);
 				client.log('this is my message I want to log');
 			});
 
@@ -143,7 +143,7 @@ describe('logging', () => {
 						done();
 					}
 				};
-				const client = new LoggingClient('my-app-id', mockLogger);
+				const client = new LoggingClient('my-app-id', false, mockLogger);
 				client.logBatch(messages);
 			});
 
@@ -173,7 +173,7 @@ describe('logging', () => {
 						done();
 					}
 				};
-				const client = new LoggingClient('my-app-id', mockLogger);
+				const client = new LoggingClient('my-app-id', false, mockLogger);
 				client.error(error, message);
 			});
 
@@ -205,7 +205,7 @@ describe('logging', () => {
 						done();
 					}
 				};
-				const client = new LoggingClient('my-app-id', mockLogger);
+				const client = new LoggingClient('my-app-id', false, mockLogger);
 				client.errorBatch(errors);
 			});
 
@@ -244,7 +244,7 @@ describe('logging', () => {
 						done();
 					}
 				};
-				const client = new LoggingClient('my-app-id', mockLogger);
+				const client = new LoggingClient('my-app-id', false, mockLogger);
 				client.legacyError(message, source, lineno, colno, error, developerMessage);
 			});
 
@@ -280,7 +280,7 @@ describe('logging', () => {
 						done();
 					}
 				};
-				const client = new LoggingClient('my-app-id', mockLogger);
+				const client = new LoggingClient('my-app-id', false, mockLogger);
 				client.legacyErrorBatch(legacyErrors);
 			});
 

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -126,7 +126,7 @@ describe('logging', () => {
 							done();
 						}
 					};
-					const client = new LoggingClient('my-app-id', {}, mockLogger);
+					const client = new LoggingClient('my-app-id', mockLogger);
 					client.log('this is my message I want to log');
 				});
 
@@ -148,7 +148,7 @@ describe('logging', () => {
 							done();
 						}
 					};
-					const client = new LoggingClient('my-app-id', {}, mockLogger);
+					const client = new LoggingClient('my-app-id', mockLogger);
 					client.logBatch(messages);
 				});
 
@@ -180,7 +180,7 @@ describe('logging', () => {
 							done();
 						}
 					};
-					const client = new LoggingClient('my-app-id', {}, mockLogger);
+					const client = new LoggingClient('my-app-id', mockLogger);
 					client.error(error, message);
 				});
 
@@ -214,7 +214,7 @@ describe('logging', () => {
 							done();
 						}
 					};
-					const client = new LoggingClient('my-app-id', {}, mockLogger);
+					const client = new LoggingClient('my-app-id', mockLogger);
 					client.errorBatch(errors);
 				});
 
@@ -255,7 +255,7 @@ describe('logging', () => {
 							done();
 						}
 					};
-					const client = new LoggingClient('my-app-id', {}, mockLogger);
+					const client = new LoggingClient('my-app-id', mockLogger);
 					client.legacyError(message, source, lineno, colno, error, developerMessage);
 				});
 
@@ -293,7 +293,7 @@ describe('logging', () => {
 							done();
 						}
 					};
-					const client = new LoggingClient('my-app-id', {}, mockLogger);
+					const client = new LoggingClient('my-app-id', mockLogger);
 					client.legacyErrorBatch(legacyErrors);
 				});
 


### PR DESCRIPTION
Fixes https://github.com/BrightspaceUI/logging/issues/6.

Putting this up now to start discussions while I work on adding tests.  This is an alternative to https://github.com/Brightspace/lms/pull/7639, allowing apps that create their own client to use our throttling code as well.  Throttling defaults to false.

----

This change updates the JavaScript error logger to send each unique error only once per minute (per page load).

This helps us determine the actual top errors affecting the most people more easily. Right now, we have specific errors that are being thrown by one client (or sometimes even one person with a bad browser extension), sending us thousands of errors a minute.

This also helps keep logging costs lower, while still keeping all the information we would need to debug an error.