### PR TITLE
feat: suppressing benign JS errors

### DIFF
--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,5 +1,5 @@
 import { aTimeout, expect } from '@open-wc/testing';
-import { LogBuilder, LoggingClient, ServerLogger } from '../logging.js';
+import { benignErrors, LogBuilder, LoggingClient, ServerLogger } from '../logging.js';
 import sinon from 'sinon';
 
 const defaultThrottleRateMs = 60000;
@@ -249,6 +249,18 @@ describe('logging', () => {
 						}
 					});
 					client.legacyError(message, source, lineno, colno, error, developerMessage);
+				});
+
+				benignErrors.forEach((message) => {
+					it(`should not log benign legacy error "${message}"`, () => {
+						const stub = sinon.stub();
+						const client = new LoggingClient('my-app-id', {
+							logBatch: stub
+						});
+						client.legacyError(message, 'logging.js', 102, 23, new Error('An error occurred'), 'dev msg');
+						expect(client._uniqueLogs).to.be.empty;
+						expect(stub).to.not.have.been.called;
+					});
 				});
 
 				it('should log legacy error batch', (done) => {


### PR DESCRIPTION
Suppresses errors that we've deemed "benign" -- the resize observer loop limit exceeded error and the generic "Script error.". This should reduce the amount of logging we do by ~27% since we're ignoring these errors in our reports anyway.

I only ignore these in `legacyError()` (and `legacyErrorBatch()`) and not in `error()` since that's what the monolith calls into in its `onerror` handler. Doing it elsewhere would be easy enough if we want.